### PR TITLE
Fix netcat package

### DIFF
--- a/docker/daiquiri/dockerfile.tpl
+++ b/docker/daiquiri/dockerfile.tpl
@@ -10,6 +10,8 @@ ENV INIT_FINISHED_FILE=${HOME}/run/init.finished
 
 ENV PATH=${PATH}:/home/dq/sh:/home/dq/.local/bin:${HOME}/bin:${HOME}/sh:/vol/tools/shed
 
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
+
 RUN apt update -y
 RUN apt update -y && apt install -y \
     curl \

--- a/docker/daiquiri/dockerfile.tpl
+++ b/docker/daiquiri/dockerfile.tpl
@@ -17,7 +17,7 @@ RUN apt update -y && apt install -y \
     gettext \
     git \
     jq \
-    netcat \
+    netcat-traditional \
     python3 \
     python3-dev \
     python3-pip \


### PR DESCRIPTION
This PR solves two issues:

 - since Debian "bookworm" the netcat package is only available as "netcat-openbsd" or "netcat-traditional". I set it to the latter
 - From now on, the installation of packages outside of venv  is not allowed(see, https://peps.python.org/pep-0668/   and https://github.com/pypa/pip/issues/11776) . Setting the envvariable `PIP_BREAK_SYSTEM_PACKAGES 1` allows it again.