### PR TITLE
overhaul conf and add build_no_cache argument

### DIFF
--- a/conf/baseconf.toml
+++ b/conf/baseconf.toml
@@ -36,13 +36,7 @@ dq_app = "/home/dq/app"
 # testdata = "/vol/testdata"
 
 [docker_container_labels]
-daiquiri = [
-  # "traefik.enable=true",
-  # "traefik.http.routers.dqdev.entrypoints=websecure",
-  # "traefik.http.routers.dqdev.rule=\"Host(`dqdev.localhost`) || Host(`dqdev.aip.de`)\"",
-  # "traefik.http.routers.dqdev.service=\"dqdev\"",
-  # "traefik.http.services.dqdev.loadbalancer.server.port=8080"
-]
+daiquiri = []
 pgapp = []
 pgdata = []
 rabbitmq = []
@@ -60,11 +54,14 @@ daiquiri = 9280
 # enter your hostname below and set 'url_protocol' to 'https'
 url_hostname = "localhost:9280"
 url_protocol = "http"
+url_base = "<URL_PROTOCOL>://<URL_HOSTNAME>"
+site_url = "<URL_PROTOCOL>://<URL_HOSTNAME>"
 database_app = "postgresql://<PGAPP_DB_USER>:<PGAPP_DB_PASS>@<CONTAINER_PGAPP>/daiquiri_app"
 database_data = "postgresql://<PGDATA_DB_USER>:<PGDATA_DB_PASS>@<CONTAINER_PGDATA>/daiquiri_data"
 allowed_hosts = "*"
 secret_key = "verysecretkey"
 debug = true
+proxy = true
 auto_create_admin_user = true
 auto_pip_install_app_requirements = true
 pip_force_reinstall_app_requirements = false
@@ -88,16 +85,15 @@ async = false
 celery_broker_url = "amqp://<RABBITMQ_USER>:<RABBITMQ_PASS>@<CONTAINER_RABBITMQ>:5672/<RABBITMQ_VHOST>"
 celeryd_log_level = "INFO"
 enable_gunicorn = false
-docs_git_url = "https://gitlab.aip.de/django-daiquiri/cosmosim-content.git"
+# docs_git_url = "https://gitlab.aip.de/django-daiquiri/cosmosim-content.git"
 # add_to_supervisord_conf = [
-#     "[program:lunr-indexer]",
-#     "command = lunr-indexer /home/dq/docs/docs -o /home/dq/docs/lunr-index.json -w -f",
+#     "[program:rmq_worker_new_worker]",
+#     "command = run-rmq-worker.sh new_worker 1",
 #     "[program:webhook]",
 #     "command = webhook --port 9000 --verbose --hooks /home/dq/hooks.yaml"
 # ]
 caddyfile = "/home/dq/conf/Caddyfile"
 crontab = "/home/dq/conf/crontab"
-url_base = "<URL_PROTOCOL>://<URL_HOSTNAME>"
 
 [env]
 [env.pgapp]
@@ -118,7 +114,7 @@ rabbitmq_logs = "-"
 # define additional packages that are installed during the docker container
 # build process from the base image's repositories, uncomment below
 [additional_packages]
-# daiquiri = [ "wget", "procps" ]
+# daiquiri = [ "libpq-dev", "python3-venv", "zip", "wget", "procps" ]
 # pgapp = [ "procps" ]
 # pgdata = [ "procps" ]
 
@@ -134,11 +130,11 @@ rabbitmq_logs = "-"
 # pgdata = "<HOME>/<ACTIVE_APP>/bash_scripts/build"
 
 [custom_scripts.init]
-# daiquiri = ""
+# daiquiri = "<HOME>/bash_scripts/init"
 # pgapp = ""
 # pgdata = ""
 
 [custom_scripts.up]
-# daiquiri = ""
+# daiquiri = "<HOME>/bash_scripts/up"
 # pgapp = ""
 # pgdata = ""

--- a/manage.py
+++ b/manage.py
@@ -27,6 +27,14 @@ parser.add_argument(
     help="build a profile's containers, exit when done",
 )
 parser.add_argument(
+    "-bnc",
+    "--build_no_cache",
+    type=str,
+    nargs="*",
+    default=None,
+    help="build a profile's containers without using cache, exit when done",
+)
+parser.add_argument(
     "-r",
     "--run",
     type=str,
@@ -166,6 +174,12 @@ if __name__ == "__main__":
         dco.render_dockerfile_templates()
         run = Runner(conf)
         run.build()
+
+    if args.build_no_cache is not None:
+        dco.render_dc_yaml(conf["args"]["run"])
+        dco.render_dockerfile_templates()
+        run = Runner(conf)
+        run.build_no_cache()
 
     if args.run is not None:
         dco.render_dc_yaml(conf["args"]["run"])

--- a/manage.py
+++ b/manage.py
@@ -165,7 +165,6 @@ if __name__ == "__main__":
         dco.render_dc_yaml(conf["args"]["run"])
         dco.render_dockerfile_templates()
         run = Runner(conf)
-        run.create_network()
         run.build()
 
     if args.run is not None:

--- a/py/runner.py
+++ b/py/runner.py
@@ -52,6 +52,9 @@ class Runner:
     def build(self):
         self.run_compose(["build"])
 
+    def build_no_cache(self):
+        self.run_compose(["build", "--no-cache"])
+
     def start(self):
         self.run_compose(["up", "--build", "-d"])
         self.tail_logs()


### PR DESCRIPTION
This PR adds following changes:

 - `create_network()` is removed from `manage.py` since the function doesn't exist anymore
 - small overhaul of the baseconf. For example, `proxy` and `site_url` are added since they are always needed for each daiquiri-app instance. Some other small tweaks that should not affect the overall functionality of `dq-dev`
  - `--build_no_chache` (`-bnc`) argument is added to `manage.py`. This argument allows to rebuild an image from scratch.  Personally, I needed this function quiet a few times to fix a broken image that refused to properly install `[additional_packages]` which are defined in `conf.toml`.