### PR TITLE
use gthread instead of gevent to allow multithreading

### DIFF
--- a/docker/daiquiri/rootfs/home/dq/sh/run-web-server.sh
+++ b/docker/daiquiri/rootfs/home/dq/sh/run-web-server.sh
@@ -12,7 +12,7 @@ if [[ -z "$(ps aux | grep "[g]unicorn")" ]]; then
             --access-logfile=/dev/stdout \
             --worker-class gthread \
             --workers 2 \
-            --threads 2 \
+            --threads 8 \
             config.wsgi:application
     else
         # django dev server for development, has auto reload, does not cache

--- a/docker/daiquiri/rootfs/home/dq/sh/run-web-server.sh
+++ b/docker/daiquiri/rootfs/home/dq/sh/run-web-server.sh
@@ -10,8 +10,9 @@ if [[ -z "$(ps aux | grep "[g]unicorn")" ]]; then
         gunicorn --bind 0.0.0.0:8000 \
             --log-file=/dev/stdout \
             --access-logfile=/dev/stdout \
-            --worker-class gevent \
+            --worker-class gthread \
             --workers 2 \
+            --threads 2 \
             config.wsgi:application
     else
         # django dev server for development, has auto reload, does not cache


### PR DESCRIPTION
We are currently using `gevent`  as a worker-class for Gunicorn which can handle high volume of concurrent HTTP requests. However, it's impossible to use multi-threading in the daiquiri-apps ( for example the `threading` library). 
The alternative is to use the `gthread` worker which can handle not only the concurrent HTTP request but also the OS-level threads. AFAIK, the downside for using `gthread` is potentially a higher resource consumption by high number of simultaneous connections . For some apps that use multi-threading, `gthread` is required to work at all. 
IMHO, there are two possible solutions:
 - we change `gevent` to `gthread`. I'm not sure what would be the appropriate number of workers and threads in this case. atm, this is my preferred solution.
 - we make another conf variable (multithreading?). If the variable is set to true then `dq-dev` uses `gthread` instead of `gevent` for Gunicorn. This solution is more flexible but adds another variable to the config which is already somewhat overcrowded.
 